### PR TITLE
Provide an example configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN mkdir /opt/flume
 RUN wget -qO- http://archive.apache.org/dist/flume/1.6.0/apache-flume-1.6.0-bin.tar.gz \
   | tar zxvf - -C /opt/flume --strip 1
 
+ENV FLUME_CONF_DIR /opt/flume/conf
 ADD start-flume.sh /opt/flume/bin/start-flume
 
 ENV JAVA_HOME /opt/java

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:jessie
 MAINTAINER Alex Wilson a.wilson@alumni.warwick.ac.uk
 
-RUN apt-get update && apt-get install -q -y --no-install-recommends wget
+RUN apt-get update && apt-get install -q -y --no-install-recommends wget netcat
 
 RUN mkdir /opt/java
 RUN wget --no-check-certificate --header "Cookie: oraclelicense=accept-securebackup-cookie" -qO- \
@@ -12,7 +12,11 @@ RUN mkdir /opt/flume
 RUN wget -qO- http://archive.apache.org/dist/flume/1.6.0/apache-flume-1.6.0-bin.tar.gz \
   | tar zxvf - -C /opt/flume --strip 1
 
+ENV FLUME_AGENT_NAME a1
 ENV FLUME_CONF_DIR /opt/flume/conf
+ENV FLUME_CONF_FILE $FLUME_CONF_DIR/example-a1.conf
+
+ADD example-a1.conf $FLUME_CONF_DIR/example-a1.conf
 ADD start-flume.sh /opt/flume/bin/start-flume
 
 ENV JAVA_HOME /opt/java

--- a/README.md
+++ b/README.md
@@ -1,25 +1,68 @@
 ## docker-flume
 
-  Docker image containing [Apache Flume](https://flume.apache.org/)
-
-## Build Instructions
-
-    docker build -t flume .
+Docker image containing [Apache Flume](https://flume.apache.org/)
 
 ## Available environment variables
 
- * `FLUME_AGENT_NAME` - name of flume agent to run. **Required**
- * `FLUME_CONF_FILE` - location of flume configuration file. **Required**
- * `FLUME_CONF_DIR` - directory for flume environment/configuration files. Defaults to `/opt/flume/conf`
+* `FLUME_AGENT_NAME` - name of flume agent to run.  Defaults to `a1`.
+* `FLUME_CONF_DIR` - directory for flume environment/configuration files. Defaults to `/opt/flume/conf`.
+* `FLUME_CONF_FILE` - location of flume configuration file. Defaults to `$FLUME_CONF_DIR/example-a1.conf`.
 
 ## Example usage
 
-    FROM probablyfine/flume
-    ADD flume.conf /var/tmp/flume.conf
+### Using the sample Flume configuration
 
-And to run
+Build the image:
 
-    docker run \
-      -e FLUME_AGENT_NAME=someagent \
-      -e FLUME_CONF_FILE=/var/tmp/flume.conf \
-      my-flume-image
+```bash
+    docker build -t flume .
+```
+
+Create container:
+
+```bash
+docker run -ti --name=flume-example-a1 flume
+```
+
+In another terminal, send an event to Flume:
+
+```bash
+docker exec -i -t flume-example-a1 bash -c 'echo "Hello world" | nc -q 1 localhost 44444'
+OK
+```
+
+In the terminal where you ran the Docker container you should now see the message in the Flume console:
+
+```
+2016-03-27 23:49:32,727 (SinkRunner-PollingRunner-DefaultSinkProcessor) [INFO - org.apache.flume.sink.LoggerSink.process(LoggerSink.java:94)] Event: { headers:{} body: 48 65 6C 6C 6F 20 77 6F 72 6C 64 21             Hello world! }
+```
+
+Use `CTRL+c` to stop the container and then you can delete it:
+
+``` bash
+docker rm flume-example-a1
+```
+
+### Using your own Flume configuration
+
+Create your own `Dockerfile` using this as the base image and include the Flume configuration file:
+
+```Dockerfile
+FROM probablyfine/flume
+ADD flume.conf /var/tmp/flume.conf
+```
+
+Build it:
+
+```bash
+docker build -t my-flume-image .
+```
+
+And to run:
+
+```bash
+docker run \
+  -e FLUME_AGENT_NAME=someagent \
+  -e FLUME_CONF_FILE=/var/tmp/flume.conf \
+  my-flume-image
+```

--- a/example-a1.conf
+++ b/example-a1.conf
@@ -1,0 +1,24 @@
+# From https://flume.apache.org/FlumeUserGuide.html
+# See Dockerfile for "ENV FLUME_AGENT_NAME a1"
+
+# Name the components on this agent
+a1.sources = r1
+a1.sinks = k1
+a1.channels = c1
+
+# Describe/configure the source
+a1.sources.r1.type = netcat
+a1.sources.r1.bind = localhost
+a1.sources.r1.port = 44444
+
+# Describe the sink
+a1.sinks.k1.type = logger
+
+# Use a channel which buffers events in memory
+a1.channels.c1.type = memory
+a1.channels.c1.capacity = 1000
+a1.channels.c1.transactionCapacity = 100
+
+# Bind the source and sink to the channel
+a1.sources.r1.channels = c1
+a1.sinks.k1.channel = c1

--- a/start-flume.sh
+++ b/start-flume.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-FLUME_CONF_DIR=${FLUME_CONF_DIR:-/opt/flume/conf}
-
 [[ -z "${FLUME_CONF_FILE}"  ]] && { echo "FLUME_CONF_FILE required";  exit 1; }
 [[ -z "${FLUME_AGENT_NAME}" ]] && { echo "FLUME_AGENT_NAME required"; exit 1; }
 
@@ -12,4 +10,3 @@ flume-ng agent \
   -f ${FLUME_CONF_FILE} \
   -n ${FLUME_AGENT_NAME} \
   -Dflume.root.logger=INFO,console
-


### PR DESCRIPTION
This uses the [example configuration](https://flume.apache.org/FlumeUserGuide.html#a-simple-example) from the [Flume User Guide](https://flume.apache.org/FlumeUserGuide.html) as the default configuration for the image.

It allows someone to have a quick play with Flume without having to write their own configuration file.  It still supports a user-supplied configuration file as before.

I updated the README to reflect the changes made.  Let me know if you want anything changed.

See below for output of building and running in my environment.

``` bash
$ docker build -t my-flume-image .
Sending build context to Docker daemon 90.62 kB
Step 1 : FROM debian:jessie
 ---> 040bf8e08425
Step 2 : MAINTAINER Alex Wilson a.wilson@alumni.warwick.ac.uk
 ---> Using cache
 ---> 3900b63c5bad
Step 3 : RUN apt-get update && apt-get install -q -y --no-install-recommends wget netcat
 ---> Using cache
 ---> c0e599a55d25
Step 4 : RUN mkdir /opt/java
 ---> Using cache
 ---> 53b219132974
Step 5 : RUN wget --no-check-certificate --header "Cookie: oraclelicense=accept-securebackup-cookie" -qO-   https://download.oracle.com/otn-pub/java/jdk/8u20-b26/jre-8u20-linux-x64.tar.gz   | tar zxvf - -C /opt/java --strip 1
 ---> Using cache
 ---> 4ee229e5b651
Step 6 : RUN mkdir /opt/flume
 ---> Using cache
 ---> 2375d4ec81c5
Step 7 : RUN wget -qO- http://archive.apache.org/dist/flume/1.6.0/apache-flume-1.6.0-bin.tar.gz   | tar zxvf - -C /opt/flume --strip 1
 ---> Using cache
 ---> fa6a7a60d6b4
Step 8 : ENV FLUME_AGENT_NAME a1
 ---> Using cache
 ---> 40f08bb37bd2
Step 9 : ENV FLUME_CONF_DIR /opt/flume/conf
 ---> Using cache
 ---> 40d4e44c6d7f
Step 10 : ENV FLUME_CONF_FILE $FLUME_CONF_DIR/example-a1.conf
 ---> Using cache
 ---> 3e73e96b62a8
Step 11 : ADD example-a1.conf $FLUME_CONF_DIR/example-a1.conf
 ---> Using cache
 ---> 4f93f638d23b
Step 12 : ADD start-flume.sh /opt/flume/bin/start-flume
 ---> 812d8fae7f55
Removing intermediate container 24a607246fe1
Step 13 : ENV JAVA_HOME /opt/java
 ---> Running in 11015b0e5d48
 ---> cdb66ff058a2
Removing intermediate container 11015b0e5d48
Step 14 : ENV PATH /opt/flume/bin:/opt/java/bin:$PATH
 ---> Running in 66b499e646e1
 ---> 37e5cc2aef98
Removing intermediate container 66b499e646e1
Step 15 : CMD start-flume
 ---> Running in b9edd26c020f
 ---> a7cbf53399d4
Removing intermediate container b9edd26c020f
Successfully built a7cbf53399d4
```

```
$ docker --tls run -ti --name=flume-example-a1 flume
Starting flume agent : a1
Info: Including Hive libraries found via () for Hive access
+ exec /opt/java/bin/java -Xmx20m -Dflume.root.logger=INFO,console -cp '/opt/flume/conf:/opt/flume/lib/*:/lib/*' -Djava.library.path= org.apache.flume.node.Application -f /opt/flume/conf/example-a1.conf -n a1
2016-03-28 01:30:40,125 (lifecycleSupervisor-1-0) [INFO - org.apache.flume.node.PollingPropertiesFileConfigurationProvider.start(PollingPropertiesFileConfigurationProvider.java:61)] Configuration provider starting
2016-03-28 01:30:40,131 (conf-file-poller-0) [INFO - org.apache.flume.node.PollingPropertiesFileConfigurationProvider$FileWatcherRunnable.run(PollingPropertiesFileConfigurationProvider.java:133)] Reloading configuration file:/opt/flume/conf/example-a1.conf
2016-03-28 01:30:40,140 (conf-file-poller-0) [INFO - org.apache.flume.conf.FlumeConfiguration$AgentConfiguration.addProperty(FlumeConfiguration.java:931)] Added sinks: k1 Agent: a1
2016-03-28 01:30:40,141 (conf-file-poller-0) [INFO - org.apache.flume.conf.FlumeConfiguration$AgentConfiguration.addProperty(FlumeConfiguration.java:1017)] Processing:k1
2016-03-28 01:30:40,141 (conf-file-poller-0) [INFO - org.apache.flume.conf.FlumeConfiguration$AgentConfiguration.addProperty(FlumeConfiguration.java:1017)] Processing:k1
2016-03-28 01:30:40,155 (conf-file-poller-0) [INFO - org.apache.flume.conf.FlumeConfiguration.validateConfiguration(FlumeConfiguration.java:141)] Post-validation flume configuration contains configuration for agents: [a1]
2016-03-28 01:30:40,155 (conf-file-poller-0) [INFO - org.apache.flume.node.AbstractConfigurationProvider.loadChannels(AbstractConfigurationProvider.java:145)] Creating channels
2016-03-28 01:30:40,164 (conf-file-poller-0) [INFO - org.apache.flume.channel.DefaultChannelFactory.create(DefaultChannelFactory.java:42)] Creating instance of channel c1 type memory
2016-03-28 01:30:40,169 (conf-file-poller-0) [INFO - org.apache.flume.node.AbstractConfigurationProvider.loadChannels(AbstractConfigurationProvider.java:200)] Created channel c1
2016-03-28 01:30:40,169 (conf-file-poller-0) [INFO - org.apache.flume.source.DefaultSourceFactory.create(DefaultSourceFactory.java:41)] Creating instance of source r1, type netcat
2016-03-28 01:30:40,180 (conf-file-poller-0) [INFO - org.apache.flume.sink.DefaultSinkFactory.create(DefaultSinkFactory.java:42)] Creating instance of sink: k1, type: logger
2016-03-28 01:30:40,184 (conf-file-poller-0) [INFO - org.apache.flume.node.AbstractConfigurationProvider.getConfiguration(AbstractConfigurationProvider.java:114)] Channel c1 connected to [r1, k1]
2016-03-28 01:30:40,194 (conf-file-poller-0) [INFO - org.apache.flume.node.Application.startAllComponents(Application.java:138)] Starting new configuration:{ sourceRunners:{r1=EventDrivenSourceRunner: { source:org.apache.flume.source.NetcatSource{name:r1,state:IDLE} }} sinkRunners:{k1=SinkRunner: { policy:org.apache.flume.sink.DefaultSinkProcessor@1bb1ba33 counterGroup:{ name:null counters:{} } }} channels:{c1=org.apache.flume.channel.MemoryChannel{name: c1}} }
2016-03-28 01:30:40,206 (conf-file-poller-0) [INFO - org.apache.flume.node.Application.startAllComponents(Application.java:145)] Starting Channel c1
2016-03-28 01:30:40,282 (lifecycleSupervisor-1-0) [INFO - org.apache.flume.instrumentation.MonitoredCounterGroup.register(MonitoredCounterGroup.java:120)] Monitored counter group for type: CHANNEL, name: c1: Successfully registered new MBean.
2016-03-28 01:30:40,283 (lifecycleSupervisor-1-0) [INFO - org.apache.flume.instrumentation.MonitoredCounterGroup.start(MonitoredCounterGroup.java:96)] Component type: CHANNEL, name: c1 started
2016-03-28 01:30:40,286 (conf-file-poller-0) [INFO - org.apache.flume.node.Application.startAllComponents(Application.java:173)] Starting Sink k1
2016-03-28 01:30:40,293 (conf-file-poller-0) [INFO - org.apache.flume.node.Application.startAllComponents(Application.java:184)] Starting Source r1
2016-03-28 01:30:40,294 (lifecycleSupervisor-1-2) [INFO - org.apache.flume.source.NetcatSource.start(NetcatSource.java:150)] Source starting
2016-03-28 01:30:40,309 (lifecycleSupervisor-1-2) [INFO - org.apache.flume.source.NetcatSource.start(NetcatSource.java:164)] Created serverSocket:sun.nio.ch.ServerSocketChannelImpl[/127.0.0.1:44444]
```

``` bash
$ docker exec -i -t flume-example-a1 bash -c 'echo "Hello world" | nc -q 1 localhost 44444'
OK
```

``` bash
2016-03-28 01:31:18,306 (SinkRunner-PollingRunner-DefaultSinkProcessor) [INFO - org.apache.flume.sink.LoggerSink.process(LoggerSink.java:94)] Event: { headers:{} body: 48 65 6C 6C 6F 20 77 6F 72 6C 64                Hello world }
```
